### PR TITLE
Buffer is not initialized but can be freed. (#105)

### DIFF
--- a/gradle/fmp-library/library/src/main/jni/player/ffmpeg_mediaplayer.c
+++ b/gradle/fmp-library/library/src/main/jni/player/ffmpeg_mediaplayer.c
@@ -773,7 +773,7 @@ int stream_component_open(VideoState *is, int stream_index) {
 	is->audio_callback = audio_callback;
 
     // Set audio settings from codec info
-	AudioPlayer *player = malloc(sizeof(AudioPlayer));
+    AudioPlayer *player = calloc(1, sizeof(AudioPlayer));
     is->audio_player = player;
     createEngine(&is->audio_player);
     createBufferQueueAudioPlayer(&is->audio_player, is, codecCtx->channels, codecCtx->sample_rate);


### PR DESCRIPTION
AudioPlayer.buffer is not initialized and freed.
This can cause signal 11, SIGSEGV or unpredictable failure.